### PR TITLE
ENG-3423 Fixed secondary languages friendly code issue

### DIFF
--- a/src/main/java/org/entando/entando/plugins/jpseo/aps/system/services/controller/control/RequestValidator.java
+++ b/src/main/java/org/entando/entando/plugins/jpseo/aps/system/services/controller/control/RequestValidator.java
@@ -91,16 +91,7 @@ public class RequestValidator extends com.agiletec.aps.system.services.controlle
                 lang = getLangManager().getLang(sect1);
                 String friendlyCode = matcher.group(2).substring(1);
                 FriendlyCodeVO vo = this.getSeoMappingManager().getReference(friendlyCode);
-                if (null != vo && null != lang && lang.getCode().equals(vo.getLangCode())) {
-                    if (null != vo.getPageCode()) {
-                        page = this.getPageManager().getOnlinePage(vo.getPageCode());
-					} else if (null != vo.getContentId()) {
-                        String contentId = vo.getContentId();
-                        String viewPageCode = this.getContentManager().getViewPage(contentId);
-                        page = this.getPageManager().getOnlinePage(viewPageCode);
-                        reqCtx.addExtraParam(JpseoSystemConstants.EXTRAPAR_HIDDEN_CONTENT_ID, contentId);
-                    }
-                }
+                page = this.getPage(vo, lang, reqCtx);
             }
         } else if (this.getResourcePath(reqCtx).equals("/pages")) {
             resourcePath = getFullResourcePath(reqCtx);
@@ -139,6 +130,22 @@ public class RequestValidator extends com.agiletec.aps.system.services.controlle
         reqCtx.addExtraParam(SystemConstants.EXTRAPAR_CURRENT_PAGE, page);
         return true;
     }
+
+	private IPage getPage(FriendlyCodeVO vo, Lang lang, RequestContext reqCtx) {
+		IPage page = null;
+		if (null != vo && null != lang) {
+			if (null != vo.getPageCode() && lang.getCode().equals(vo.getLangCode())) {
+				page = this.getPageManager().getOnlinePage(vo.getPageCode());
+			} else if (null != vo.getContentId() && (lang.getCode().equals(vo.getLangCode())
+					|| vo.getContentId().equals(reqCtx.getRequest().getParameter("contentId")))) {
+				String contentId = vo.getContentId();
+				String viewPageCode = this.getContentManager().getViewPage(contentId);
+				page = this.getPageManager().getOnlinePage(viewPageCode);
+				reqCtx.addExtraParam(JpseoSystemConstants.EXTRAPAR_HIDDEN_CONTENT_ID, contentId);
+			}
+		}
+		return page;
+	}
 	
 	/**
 	 * Qualora si usasse il mapping /pages/*


### PR DESCRIPTION
This PR solves 2 separate issues related to the "on-the-fly publishing" feature.

When a "News" is created defining only the title in the default language (like in the case of the OOTB contents), its link in a secondary language is built as follow:

    http://localhost:8080/entando-de-app/page/it/entando_and_jhipster_how_it_works?contentId=NWS5

Due to a [change made last year to the RequestValidator class](https://github.com/entando/entando-plugin-jpseo/commit/9e3bdb6771c23cd6fcdc9b72d5bdb8b7bed0588f#diff-27322d4174225950337e8968897ae9ec36911f8f74cf30ed7b362fc37fcb7dcaL92) the app returned a 404 error page because there was no friendly code associated with that content for the desired language. In the past there was no checking on the language, so the page was always displayed when a valid content associated with the requested friendly code was found.

I found a test case for the 404 condition, so I assumed that checking for language/friendlycode mismatch is a requirement.

To solve the issue, I added an extra condition that checks for the presence of the `contentId` parameter and in that case accepts the friendly code of the default language, even if the language specified by the request is a different one.
The strictest way to handle this would be to accept a language/friendlycode mismatch only if a friendly code for the requested language doesn't exist, but that would implied to make an extra query.

Second issue appeared when a title in a secondary language was added to the content.
The mapping wasn't updated, so the URL was still generated using the default language friendly code.
This happened because in the `SeoMappingManager` class the mapping update was skipped when a mapping already existed. 

I found a test case checking that an existing mapping can't be updated, so preventing the update of an existing mapping seems a requirement too. However the check in the `SeoMappingManager` was too rough and didn't consider the case when a new language is added. The change in this PR prevents updating an existing mapping for a given language but allows to add a new mapping if a new language attribute is set.

Summarizing, if a "News" is created with the English title only, it will have the following URL when site language is set to English:

    /page/en/english_title?contentId=XXX

The page will be reachable also when site language is set to Italian, using the same friendly code:

    /page/it/english_title?contentId=XXX

If the Italian title is added, then it will be reachable also in this way:

    /page/it/italian_title?contentId=XXX

Once a friendly code for a given language has been defined, changing the content title will have no effect on the friendly code.